### PR TITLE
fix: atualizar URLs de jogo para links corretos no componente GamesSection

### DIFF
--- a/src/components/games-section.tsx
+++ b/src/components/games-section.tsx
@@ -17,8 +17,8 @@ export function GamesSection() {
         "Jogo de RPG 2D com sistema de combate por turnos, inventário e progressão de personagem.",
       technologies: ["Unity", "C#", "SQLite", "Photon"],
       trailerUrl: "/rpg-game-trailer-gameplay.jpg",
-      playUrl: "#",
-      githubUrl: "#",
+      playUrl: "https://rogeriocordeiro.github.io/tetris/",
+      githubUrl: "https://github.com/RogerioCordeiro/tetris",
     },
     {
       title: "Puzzle Platformer",
@@ -31,8 +31,8 @@ export function GamesSection() {
         "LocalStorage",
       ],
       trailerUrl: "/puzzle-platformer-game-trailer.jpg",
-      playUrl: "#",
-      githubUrl: "#",
+      playUrl: "https://rogeriocordeiro.github.io/tetris/",
+      githubUrl: "https://github.com/RogerioCordeiro/tetris",
     },
     {
       title: "Multiplayer Racing",
@@ -40,8 +40,8 @@ export function GamesSection() {
         "Jogo de corrida multiplayer em tempo real com sistema de ranking e customização.",
       technologies: ["Node.js", "Socket.io", "Three.js", "WebGL"],
       trailerUrl: "/multiplayer-racing-game-trailer.jpg",
-      playUrl: "#",
-      githubUrl: "#",
+      playUrl: "https://rogeriocordeiro.github.io/tetris/",
+      githubUrl: "https://github.com/RogerioCordeiro/tetris",
     },
   ];
 


### PR DESCRIPTION
Esta solicitação de pull atualiza os links para as URLs "play" e "GitHub" no componente `GamesSection` para que agora apontem para o jogo Tetris implantado e seu repositório no GitHub, em vez de valores de espaço reservado.

**Atualizações de link para a seção GamesSection:**

* Os campos `playUrl` e `githubUrl` dos jogos RPG 2D, Plataforma e Quebra-cabeça e Corrida Multijogador foram atualizados para usar os links de implantação e repositório do jogo Tetris real, substituindo os valores de espaço reservado anteriores. [[1]](diffhunk://#diff-b890a6bc5cb369f935cc90d7e8249ba12b1b8dfbf19e43252df39dcf6e54e4bbL20-R21) [[2]](diffhunk://#diff-b890a6bc5cb369f935cc90d7e8249ba12b1b8dfbf19e43252df39dcf6e54e4bbL34-R44)